### PR TITLE
fix(FEC-9080): when seeking back from end screen no play button displayed

### DIFF
--- a/src/ima-dai-event-manager.js
+++ b/src/ima-dai-event-manager.js
@@ -9,7 +9,7 @@ class ImaDAIEventManager {
   _queue: ImaDAIEventQueue;
   _dispatchEventHandler: Function;
   _eventManager: EventManager;
-  _parallelEvents: Array<string> = [Html5EventType.VOLUME_CHANGE];
+  _parallelEvents: Array<string> = [Html5EventType.VOLUME_CHANGE, Html5EventType.SEEKED];
   _stopEventDispatchingMap: {[event: string]: boolean} = {
     [Html5EventType.ENDED]: false
   };


### PR DESCRIPTION
### Description of the Changes

Firing `SEEKED` while ad break, as this event exits the player from ended state (see [here](https://github.com/kaltura/playkit-js-ui/blob/9820c3514f9537d3971217a3e68c35480a3b4fb1/src/components/engine-connector/engine-connector.js#L144))
(No risk because the scrubber is hidden in ad UI) 

### CheckLists

* [x] changes have been done against master branch, and PR does not conflict
* [ ] new unit / functional tests have been added (whenever applicable)
* [ ] test are passing in local environment
* [ ] Travis tests are passing (or test results are not worse than on master branch :))
* [ ] Docs have been updated
