### PR TITLE
fix(FEC-9081): wrong state when seeking into ad in pause mode

### DIFF
--- a/src/ima-dai.js
+++ b/src/ima-dai.js
@@ -474,7 +474,7 @@ class ImaDAI extends BasePlugin implements IAdsControllerProvider, IEngineDecora
     this._dispatchAdEvent(EventType.AD_LOADED, {ad: new Ad(event.getAd() && event.getAd().getAdId(), adOptions)});
     this._dispatchAdEvent(EventType.AD_STARTED);
     this._adStartedDispatched = true;
-    if (this.player.getVideoElement().paused) {
+    if (this._engine.paused) {
       this.pauseAd();
     }
   }

--- a/src/ima-dai.js
+++ b/src/ima-dai.js
@@ -474,6 +474,9 @@ class ImaDAI extends BasePlugin implements IAdsControllerProvider, IEngineDecora
     this._dispatchAdEvent(EventType.AD_LOADED, {ad: new Ad(event.getAd() && event.getAd().getAdId(), adOptions)});
     this._dispatchAdEvent(EventType.AD_STARTED);
     this._adStartedDispatched = true;
+    if (this.player.getVideoElement().paused) {
+      this.pauseAd();
+    }
   }
 
   _onAdFirstQuartile(): void {


### PR DESCRIPTION
### Description of the Changes

`AD_STARTED` is fired even the ad is paused. So move to pause mode in this case.

### CheckLists

* [x] changes have been done against master branch, and PR does not conflict
* [ ] new unit / functional tests have been added (whenever applicable)
* [ ] test are passing in local environment
* [ ] Travis tests are passing (or test results are not worse than on master branch :))
* [ ] Docs have been updated
