### PR TITLE
fix(FEC-9086): the screen blinking and endless spinner displayed when replay is ended

### DIFF
--- a/src/ima-dai.js
+++ b/src/ima-dai.js
@@ -7,7 +7,6 @@ import './assets/style.css';
 
 const ADS_CONTAINER_CLASS: string = 'playkit-dai-ads-container';
 const ADS_COVER_CLASS: string = 'playkit-dai-ads-cover';
-const FIRST_FRAME_LENGTH: number = 0.5;
 
 /**
  * The ima-dai plugin.
@@ -275,7 +274,7 @@ class ImaDAI extends BasePlugin implements IAdsControllerProvider, IEngineDecora
       });
       if (currentCuePoint) {
         this.logger.debug('Ad already played - skipped');
-        this.player.currentTime += FIRST_FRAME_LENGTH;
+        this._engine.currentTime = currentCuePoint.end;
       }
     });
     if (this.player.config.playback.preferNative.hls) {


### PR DESCRIPTION
### Description of the Changes

seek the already played ads via the engine directly instead of via the player which [manipulates](https://github.com/kaltura/playkit-js/blob/272a10f08976f850d35038c46d36e5f709008522/src/player.js#L657) the current time target on ended

### CheckLists

* [x] changes have been done against master branch, and PR does not conflict
* [ ] new unit / functional tests have been added (whenever applicable)
* [ ] test are passing in local environment
* [ ] Travis tests are passing (or test results are not worse than on master branch :))
* [ ] Docs have been updated
