### PR TITLE
fix(FEC-9088): play button displayed instead of pause, when playback started anew in loop (loopback)

### DIFF
--- a/src/ima-dai.js
+++ b/src/ima-dai.js
@@ -513,9 +513,18 @@ class ImaDAI extends BasePlugin implements IAdsControllerProvider, IEngineDecora
     const allCuesPlayed = !this._cuePoints.find(cuePoints => !cuePoints.played);
     const adBreak = this.player.ads.getAdBreak();
     this._dispatchAdEvent(EventType.AD_BREAK_END);
-    if (allCuesPlayed || adBreak.type === AdBreakType.POST) {
+    const dispatchAllAdsCompleted = () => {
       this._state = ImaDAIState.DONE;
       this._dispatchAdEvent(EventType.ALL_ADS_COMPLETED);
+    };
+    if (adBreak.type === AdBreakType.POST) {
+      if (this._engine.ended) {
+        dispatchAllAdsCompleted();
+      } else {
+        this.eventManager.listenOnce(this._engine, EventType.ENDED, dispatchAllAdsCompleted);
+      }
+    } else if (allCuesPlayed) {
+      dispatchAllAdsCompleted();
     }
     if (this._savedSeekTime) {
       this.player.currentTime = this._savedSeekTime;


### PR DESCRIPTION
### Description of the Changes

The issue comes from DAI SDK that fires 'AD_BREAK_ENDED' before the ad actually ended. 
This causes the player to replay without `PLAY` event (the player is still playing)
I’ve opened an issue - https://groups.google.com/forum/#!topic/ima-sdk/NrHGD2KfTlY
Listening to 'ENDED' event as a workaround solves the issue.

**Also fixes FEC-9101**

### CheckLists

* [x] changes have been done against master branch, and PR does not conflict
* [ ] new unit / functional tests have been added (whenever applicable)
* [ ] test are passing in local environment
* [ ] Travis tests are passing (or test results are not worse than on master branch :))
* [ ] Docs have been updated
