### PR TITLE
fix(FEC-9333): when playing a playlist and closing the countdown window, the next entry starts automatically

### DIFF
--- a/src/ima-dai.js
+++ b/src/ima-dai.js
@@ -359,9 +359,9 @@ class ImaDAI extends BasePlugin implements IAdsControllerProvider, IEngineDecora
   }
 
   _attachEngineListeners(): void {
-    this.eventManager.listen(this._engine, EventType.LOADED_METADATA, () => this._onLoadedMetadata());
-    this.eventManager.listen(this._engine, EventType.VOLUME_CHANGE, () => this._onVolumeChange());
-    this.eventManager.listen(this._engine, 'hlsFragParsingMetadata', event => this._onHlsFragParsingMetadata(event));
+    this.eventManager.listen(this.player.getVideoElement(), EventType.LOADED_METADATA, () => this._onLoadedMetadata());
+    this.eventManager.listen(this.player.getVideoElement(), EventType.VOLUME_CHANGE, () => this._onVolumeChange());
+    this.eventManager.listen(this.player.getVideoElement(), 'hlsFragParsingMetadata', event => this._onHlsFragParsingMetadata(event));
   }
 
   _onVolumeChange(): void {
@@ -541,7 +541,7 @@ class ImaDAI extends BasePlugin implements IAdsControllerProvider, IEngineDecora
       if (this._engine.ended) {
         dispatchAllAdsCompleted();
       } else {
-        this.eventManager.listenOnce(this._engine, EventType.ENDED, dispatchAllAdsCompleted);
+        this.eventManager.listenOnce(this.player.getVideoElement(), EventType.ENDED, dispatchAllAdsCompleted);
       }
     } else if (allCuesPlayed) {
       dispatchAllAdsCompleted();


### PR DESCRIPTION
### Description of the Changes

listen to the video element instead of to the engine which can change to be the proxy (engine decorator)

### CheckLists

* [x] changes have been done against master branch, and PR does not conflict
* [ ] new unit / functional tests have been added (whenever applicable)
* [ ] test are passing in local environment
* [ ] Travis tests are passing (or test results are not worse than on master branch :))
* [ ] Docs have been updated
