### PR TITLE
fix(FEC-10288): player is giving incorrect player.paused value during dai playback

### DIFF
--- a/src/ima-dai-engine-decorator.js
+++ b/src/ima-dai-engine-decorator.js
@@ -152,7 +152,7 @@ class ImaDAIEngineDecorator implements IEngineDecorator {
    * @memberof ImaDAIEngineDecorator
    */
   get paused(): boolean {
-    return this._plugin.isAdBreak();
+    return this._plugin.isAdBreak() ? true : this._engine.paused;
   }
 
   /**


### PR DESCRIPTION

### Description of the Changes

As far as I understood - in IMA DAI the decorator is always active (also during playback) so the paused is calculated from the decorator also in the playback. Therefore, if not in ad break the paused should return the playback paused from the engine.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
