### PR TITLE
feat(FEC-10798): support ima-dai ad breaks cue points

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -66,7 +66,7 @@ Type: [Object][48]
 -   `streamActivityMonitorId` **[string][49]** The ID to be used to debug the stream with the stream activity monitor.
 -   `authToken` **[string][49]** The stream request authorization token. Used in place of the API key for stricter content authorization. The publisher can control individual content streams authorizations based on this token.
 -   `format` **[string][49]** The stream format to request. (optional) Accepts the following string values - hls, dash (Values must be lowercase.). (optional, default `'hls'`)
--   `showAdBreakCuePoint` **[boolean][51]?** Whether to show the ad breaks cue points.
+-   `showAdBreakCuePoint` **[boolean][51]?** Whether to show the ad breaks cue points in the ui timeline.
 -   `adBreakCuePointStyle` **[Object][48]?** Style options for the ad breaks cue points - See the options [Here][55].
 
 ### Examples

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,69 +2,72 @@
 
 ### Table of Contents
 
-- [ImaDAIConfigObject][1]
-  - [Parameters][2]
-  - [Examples][3]
-- [ImaDAIAdsController][4]
-  - [Parameters][5]
-  - [skipAd][6]
-  - [playAdNow][7]
-  - [onPlaybackEnded][8]
-  - [active][9]
-  - [done][10]
-  - [name][11]
-- [ImaDAIEngineDecorator][12]
-  - [Parameters][13]
-  - [load][14]
-    - [Parameters][15]
-  - [dispatchEvent][16]
-    - [Parameters][17]
-  - [pause][18]
-  - [play][19]
-  - [reset][20]
-  - [destroy][21]
-  - [paused][22]
-  - [ended][23]
-  - [currentTime][24]
-    - [Parameters][25]
-  - [currentTime][26]
-  - [duration][27]
-- [ImaDAI][28]
-  - [Parameters][29]
-  - [getEngineDecorator][30]
-    - [Parameters][31]
-  - [getAdsController][32]
-  - [getStreamUrl][33]
-  - [state][34]
-  - [skipAd][35]
-  - [pauseAd][36]
-  - [resumeAd][37]
-  - [getStreamTime][38]
-    - [Parameters][39]
-  - [getContentTime][40]
-    - [Parameters][41]
-  - [isAdBreak][42]
-  - [reset][43]
-  - [destroy][44]
-  - [isValid][45]
-  - [defaultConfig][46]
+-   [ImaDAIConfigObject][1]
+    -   [Parameters][2]
+    -   [Examples][3]
+-   [ImaDAIAdsController][4]
+    -   [Parameters][5]
+    -   [skipAd][6]
+    -   [playAdNow][7]
+    -   [onPlaybackEnded][8]
+    -   [active][9]
+    -   [done][10]
+    -   [name][11]
+-   [ImaDAIEngineDecorator][12]
+    -   [Parameters][13]
+    -   [load][14]
+        -   [Parameters][15]
+    -   [dispatchEvent][16]
+        -   [Parameters][17]
+    -   [pause][18]
+    -   [play][19]
+    -   [reset][20]
+    -   [destroy][21]
+    -   [paused][22]
+    -   [ended][23]
+    -   [currentTime][24]
+        -   [Parameters][25]
+    -   [currentTime][26]
+    -   [duration][27]
+-   [ImaDAIState][28]
+-   [ImaDAI][29]
+    -   [Parameters][30]
+    -   [getEngineDecorator][31]
+        -   [Parameters][32]
+    -   [getAdsController][33]
+    -   [getStreamUrl][34]
+    -   [state][35]
+    -   [skipAd][36]
+    -   [pauseAd][37]
+    -   [resumeAd][38]
+    -   [getStreamTime][39]
+        -   [Parameters][40]
+    -   [getContentTime][41]
+        -   [Parameters][42]
+    -   [isAdBreak][43]
+    -   [reset][44]
+    -   [destroy][45]
+    -   [isValid][46]
+    -   [defaultConfig][47]
 
 ## ImaDAIConfigObject
 
-Type: [Object][47]
+Type: [Object][48]
 
 ### Parameters
 
-- `assetKey` **[string][48]** This is used to determine which stream should be played. The live stream request asset key is an identifier which can be [found in the DFP UI][49].
-- `contentSourceId` **[string][48]** Unique identifier for the publisher content, from a CMS. Required for on-demand streams.
-- `videoId` **[string][48]** Identifier for the video content source. Required for on-demand streams.
-- `snapback` **[boolean][50]** Prevent your viewers from seeking past your mid-roll ads. (optional, default `true`)
-- `debug` **[boolean][50]** Loads IMA-DAI SDK in debug mode. (optional, default `false`)
-- `adTagParameters` **[Object][47]** You can override a limited set of ad tag parameters on your stream request. [Supply targeting parameters to your stream][51] provides more information. You can use the dai-ot and dai-ov parameters for stream variant preference. See [Override Stream Variant Parameters][52] for more information.
-- `apiKey` **[string][48]** The stream request API key. It's configured through the [DFP Admin UI][53]. and provided to the publisher to unlock their content. It verifies the applications that are attempting to access the content.
-- `streamActivityMonitorId` **[string][48]** The ID to be used to debug the stream with the stream activity monitor.
-- `authToken` **[string][48]** The stream request authorization token. Used in place of the API key for stricter content authorization. The publisher can control individual content streams authorizations based on this token.
-- `format` **[string][48]** The stream format to request. (optional) Accepts the following string values - hls, dash (Values must be lowercase.). (optional, default `'hls'`)
+-   `assetKey` **[string][49]** This is used to determine which stream should be played. The live stream request asset key is an identifier which can be [found in the DFP UI][50].
+-   `contentSourceId` **[string][49]** Unique identifier for the publisher content, from a CMS. Required for on-demand streams.
+-   `videoId` **[string][49]** Identifier for the video content source. Required for on-demand streams.
+-   `snapback` **[boolean][51]** Prevent your viewers from seeking past your mid-roll ads. (optional, default `true`)
+-   `debug` **[boolean][51]** Loads IMA-DAI SDK in debug mode. (optional, default `false`)
+-   `adTagParameters` **[Object][48]** You can override a limited set of ad tag parameters on your stream request. [Supply targeting parameters to your stream][52] provides more information. You can use the dai-ot and dai-ov parameters for stream variant preference. See [Override Stream Variant Parameters][53] for more information.
+-   `apiKey` **[string][49]** The stream request API key. It's configured through the [DFP Admin UI][54]. and provided to the publisher to unlock their content. It verifies the applications that are attempting to access the content.
+-   `streamActivityMonitorId` **[string][49]** The ID to be used to debug the stream with the stream activity monitor.
+-   `authToken` **[string][49]** The stream request authorization token. Used in place of the API key for stricter content authorization. The publisher can control individual content streams authorizations based on this token.
+-   `format` **[string][49]** The stream format to request. (optional) Accepts the following string values - hls, dash (Values must be lowercase.). (optional, default `'hls'`)
+-   `showAdBreakCuePoint` **[boolean][51]?** Whether to show the ad breaks cue points.
+-   `adBreakCuePointStyle` **[Object][48]?** Style options for the ad breaks cue points - See the options [Here][55].
 
 ### Examples
 
@@ -84,43 +87,49 @@ Controller for ima dai plugin.
 
 ### Parameters
 
-- `context` **[ImaDAI][54]** The ima dai plugin context.
+-   `context` **[ImaDAI][56]** The ima dai plugin context.
 
 ### skipAd
 
 Skip on an ad.
 
-Returns **void**
+Returns **void** 
 
 ### playAdNow
 
 Play an ad on demand.
 
-Returns **void**
+Returns **void** 
 
 ### onPlaybackEnded
 
 On playback ended handler.
 
-Returns **[Promise][55]&lt;void>** complete promise
+Returns **[Promise][57]&lt;void>** complete promise
 
 ### active
 
 Whether this ads controller is active
 
-Returns **[boolean][50]** is active
+Type: [boolean][51]
+
+Returns **[boolean][51]** is active
 
 ### done
 
 Whether this ads controller is done
 
-Returns **[boolean][50]** is done
+Type: [boolean][51]
+
+Returns **[boolean][51]** is done
 
 ### name
 
 The controller name
 
-Returns **[string][48]** The name
+Type: [string][49]
+
+Returns **[string][49]** The name
 
 ## ImaDAIEngineDecorator
 
@@ -128,9 +137,9 @@ Engine decorator for ima dai plugin.
 
 ### Parameters
 
-- `engine` **IEngine** The HTML5 engine.
-- `plugin` **[ImaDAI][54]** The ima dai plugin.
-- `dispatchEventHandler` **[Function][56]** A dispatch event handler
+-   `engine` **IEngine** The HTML5 engine.
+-   `plugin` **[ImaDAI][56]** The ima dai plugin.
+-   `dispatchEventHandler` **[Function][58]** A dispatch event handler
 
 ### load
 
@@ -138,9 +147,9 @@ Load media.
 
 #### Parameters
 
-- `startTime` **[number][57]** Optional time to start the video from.
+-   `startTime` **[number][59]** Optional time to start the video from.
 
-Returns **[Promise][55]&lt;[Object][47]>** The loaded data
+Returns **[Promise][57]&lt;[Object][48]>** The loaded data
 
 ### dispatchEvent
 
@@ -148,67 +157,83 @@ Dispatch an event from this object.
 
 #### Parameters
 
-- `event` **[Event][58]** The event to be dispatched from this object.
+-   `event` **[Event][60]** The event to be dispatched from this object.
 
-Returns **[boolean][50]** True if the default action was prevented.
+Returns **[boolean][51]** True if the default action was prevented.
 
 ### pause
 
 Pause playback.
 
-Returns **void**
+Returns **void** 
 
 ### play
 
 Start/resume playback.
 
-Returns **void**
+Returns **void** 
 
 ### reset
 
 Resets the engine decorator.
 
-Returns **void**
+Returns **void** 
 
 ### destroy
 
 Destroys the engine decorator.
 
-Returns **void**
+Returns **void** 
 
 ### paused
 
 Get paused state.
 
-Returns **[boolean][50]** The paused value of the engine.
+Type: [boolean][51]
+
+Returns **[boolean][51]** The paused value of the engine.
 
 ### ended
 
 Get ended state.
 
-Returns **[boolean][50]** The ended value of the engine.
+Type: [boolean][51]
+
+Returns **[boolean][51]** The ended value of the engine.
 
 ### currentTime
 
 Set the current time in seconds.
 
+Type: [number][59]
+
 #### Parameters
 
-- `to` **[number][57]** The number to set in seconds.
+-   `to` **[number][59]** The number to set in seconds.
 
-Returns **void**
+Returns **void** 
 
 ### currentTime
 
 Get the current time in seconds.
 
-Returns **[number][57]** The current playback time.
+Type: [number][59]
+
+Returns **[number][59]** The current playback time.
 
 ### duration
 
 Get the duration in seconds.
 
-Returns **[number][57]** The playback duration.
+Type: [number][59]
+
+Returns **[number][59]** The playback duration.
+
+## ImaDAIState
+
+The ima DAI plugin possible states.
+
+Type: [Object][48]
 
 ## ImaDAI
 
@@ -218,9 +243,9 @@ The ima-dai plugin.
 
 ### Parameters
 
-- `name` **[string][48]** The plugin name.
-- `player` **Player** The player instance.
-- `config` **[ImaDAIConfigObject][59]** The plugin config.
+-   `name` **[string][49]** The plugin name.
+-   `player` **Player** The player instance.
+-   `config` **[ImaDAIConfigObject][61]** The plugin config.
 
 ### getEngineDecorator
 
@@ -228,8 +253,8 @@ Gets the engine decorator.
 
 #### Parameters
 
-- `engine` **IEngine** The engine to decorate.
-- `dispatchEventHandler` **[Function][56]** A dispatch event handler
+-   `engine` **IEngine** The engine to decorate.
+-   `dispatchEventHandler` **[Function][58]** A dispatch event handler
 
 Returns **IEngineDecorator** The ads api.
 
@@ -243,31 +268,33 @@ Returns **IAdsPluginController** The ads api.
 
 Gets the stream URL from ima-dai SDK.
 
-Returns **[Promise][55]&lt;[string][48]>** A promise of the URL to play.
+Returns **[Promise][57]&lt;[string][49]>** A promise of the URL to play.
 
 ### state
 
 Gets the plugin state.
 
-Returns **[string][48]** The state.
+Type: [string][49]
+
+Returns **[string][49]** The state.
 
 ### skipAd
 
 Skips on an ad.
 
-Returns **void**
+Returns **void** 
 
 ### pauseAd
 
 Pausing the ad.
 
-Returns **void**
+Returns **void** 
 
 ### resumeAd
 
 Resuming the ad.
 
-Returns **void**
+Returns **void** 
 
 ### getStreamTime
 
@@ -275,9 +302,9 @@ Returns the stream time with ads for a given content time. Returns the given con
 
 #### Parameters
 
-- `contentTime` **[number][57]** the content time without any ads (in seconds).
+-   `contentTime` **[number][59]** the content time without any ads (in seconds).
 
-Returns **[number][57]** The stream time that corresponds with the given content time once ads are inserted.
+Returns **[number][59]** The stream time that corresponds with the given content time once ads are inserted.
 
 ### getContentTime
 
@@ -285,27 +312,27 @@ Returns the content time without ads for a given stream time. Returns the given 
 
 #### Parameters
 
-- `streamTime` **[number][57]** the stream time with inserted ads (in seconds).
+-   `streamTime` **[number][59]** the stream time with inserted ads (in seconds).
 
-Returns **[number][57]** The content time that corresponds with the given stream time once ads are removed.
+Returns **[number][59]** The content time that corresponds with the given stream time once ads are removed.
 
 ### isAdBreak
 
 Whether the player is in an ad break.
 
-Returns **[boolean][50]** Is ad break.
+Returns **[boolean][51]** Is ad break.
 
 ### reset
 
 Resets the plugin.
 
-Returns **void**
+Returns **void** 
 
 ### destroy
 
 Destroys the plugin.
 
-Returns **void**
+Returns **void** 
 
 ### isValid
 
@@ -315,64 +342,126 @@ Whether the ima-dai plugin is valid.
 
 The default configuration of the plugin.
 
-Type: [Object][47]
+Type: [Object][48]
 
 [1]: #imadaiconfigobject
+
 [2]: #parameters
+
 [3]: #examples
+
 [4]: #imadaiadscontroller
+
 [5]: #parameters-1
+
 [6]: #skipad
+
 [7]: #playadnow
+
 [8]: #onplaybackended
+
 [9]: #active
+
 [10]: #done
+
 [11]: #name
+
 [12]: #imadaienginedecorator
+
 [13]: #parameters-2
+
 [14]: #load
+
 [15]: #parameters-3
+
 [16]: #dispatchevent
+
 [17]: #parameters-4
+
 [18]: #pause
+
 [19]: #play
+
 [20]: #reset
+
 [21]: #destroy
+
 [22]: #paused
+
 [23]: #ended
+
 [24]: #currenttime
+
 [25]: #parameters-5
+
 [26]: #currenttime-1
+
 [27]: #duration
-[28]: #imadai
-[29]: #parameters-6
-[30]: #getenginedecorator
-[31]: #parameters-7
-[32]: #getadscontroller
-[33]: #getstreamurl
-[34]: #state
-[35]: #skipad-1
-[36]: #pausead
-[37]: #resumead
-[38]: #getstreamtime
-[39]: #parameters-8
-[40]: #getcontenttime
-[41]: #parameters-9
-[42]: #isadbreak
-[43]: #reset-1
-[44]: #destroy-1
-[45]: #isvalid
-[46]: #defaultconfig
-[47]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
-[48]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
-[49]: https://goo.gl/wjL9DI
-[50]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
-[51]: https://support.google.com/dfp_premium/answer/7320899
-[52]: https://support.google.com/dfp_premium/answer/7320898
-[53]: https://support.google.com/admanager/answer/6381445
-[54]: #imadai
-[55]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
-[56]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
-[57]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
-[58]: https://developer.mozilla.org/docs/Web/API/Event
-[59]: #imadaiconfigobject
+
+[28]: #imadaistate
+
+[29]: #imadai
+
+[30]: #parameters-6
+
+[31]: #getenginedecorator
+
+[32]: #parameters-7
+
+[33]: #getadscontroller
+
+[34]: #getstreamurl
+
+[35]: #state
+
+[36]: #skipad-1
+
+[37]: #pausead
+
+[38]: #resumead
+
+[39]: #getstreamtime
+
+[40]: #parameters-8
+
+[41]: #getcontenttime
+
+[42]: #parameters-9
+
+[43]: #isadbreak
+
+[44]: #reset-1
+
+[45]: #destroy-1
+
+[46]: #isvalid
+
+[47]: #defaultconfig
+
+[48]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
+
+[49]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+
+[50]: https://goo.gl/wjL9DI
+
+[51]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
+
+[52]: https://support.google.com/dfp_premium/answer/7320899
+
+[53]: https://support.google.com/dfp_premium/answer/7320898
+
+[54]: https://support.google.com/admanager/answer/6381445
+
+[55]: https://github.com/kaltura/playkit-js-timeline/blob/main/docs/types.md#cuepointoptionsobject
+
+[56]: #imadai
+
+[57]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
+
+[58]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
+
+[59]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
+
+[60]: https://developer.mozilla.org/docs/Web/API/Event
+
+[61]: #imadaiconfigobject

--- a/flow-typed/types/ima-dai-config.js
+++ b/flow-typed/types/ima-dai-config.js
@@ -11,7 +11,7 @@
  * @param {string} streamActivityMonitorId - The ID to be used to debug the stream with the stream activity monitor.
  * @param {string} authToken - The stream request authorization token. Used in place of the API key for stricter content authorization. The publisher can control individual content streams authorizations based on this token.
  * @param {string} [format='hls'] - The stream format to request. (optional) Accepts the following string values - hls, dash (Values must be lowercase.).
- * @param {boolean} [showAdBreakCuePoint] - Whether to show the ad breaks cue points.
+ * @param {boolean} [showAdBreakCuePoint] - Whether to show the ad breaks cue points in the ui timeline.
  * @param {Object} [adBreakCuePointStyle] - Style options for the ad breaks cue points - See the options {@link https://github.com/kaltura/playkit-js-timeline/blob/main/docs/types.md#cuepointoptionsobject|Here}.
  * @example
  * plugins: {

--- a/flow-typed/types/ima-dai-config.js
+++ b/flow-typed/types/ima-dai-config.js
@@ -11,6 +11,8 @@
  * @param {string} streamActivityMonitorId - The ID to be used to debug the stream with the stream activity monitor.
  * @param {string} authToken - The stream request authorization token. Used in place of the API key for stricter content authorization. The publisher can control individual content streams authorizations based on this token.
  * @param {string} [format='hls'] - The stream format to request. (optional) Accepts the following string values - hls, dash (Values must be lowercase.).
+ * @param {boolean} [showAdBreakCuePoint] - Whether to show the ad breaks cue points.
+ * @param {Object} [adBreakCuePointStyle] - Style options for the ad breaks cue points - See the options {@link https://github.com/kaltura/playkit-js-timeline/blob/main/docs/types.md#cuepointoptionsobject|Here}.
  * @example
  * plugins: {
  *   imadai: {
@@ -31,7 +33,9 @@ type _ImaDAIConfigObject = {
   apiKey: string,
   streamActivityMonitorId: string,
   authToken: string,
-  format: string
+  format: string,
+  showAdBreakCuePoint: boolean,
+  adBreakCuePointStyle: Object
 };
 
 declare type ImaDAIConfigObject = _ImaDAIConfigObject;

--- a/src/ima-dai.js
+++ b/src/ima-dai.js
@@ -61,6 +61,8 @@ class ImaDAI extends BasePlugin implements IAdsControllerProvider, IEngineDecora
    */
   static defaultConfig: Object = {
     snapback: true,
+    showAdBreakCuePoint: false,
+    adBreakCuePointStyle: null,
     debug: false
   };
 
@@ -402,6 +404,15 @@ class ImaDAI extends BasePlugin implements IAdsControllerProvider, IEngineDecora
       }
     });
     this._dispatchAdEvent(EventType.AD_MANIFEST_LOADED, {adBreaksPosition: adBreaksPosition});
+    if (this.player.ui.hasManager('timeline') && this.config.showAdBreakCuePoint) {
+      adBreaksPosition.forEach(position => {
+        this.player.ui.getManager('timeline').addCuePoint({
+          time: position !== -1 ? Math.round(position) : Infinity,
+          presets: ['Playback'],
+          ...this.config.adBreakCuePointStyle
+        });
+      });
+    }
   }
 
   _onHlsFragParsingMetadata(event: FakeEvent): void {


### PR DESCRIPTION
### Description of the Changes

use the `addCuePoint` for the ad breaks when configured 

Depends on https://github.com/kaltura/playkit-js-ui/pull/573

Solves FEC-10798

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
