### PR TITLE
feat(FEC-10041): Allow ADS to be used in parallel

### DIFF
--- a/src/ima-dai-engine-decorator.js
+++ b/src/ima-dai-engine-decorator.js
@@ -3,7 +3,7 @@ import {core} from 'kaltura-player-js';
 import {ImaDAI} from './ima-dai';
 import {ImaDAIEventManager} from './ima-dai-event-manager';
 
-const {AdBreakType, AdEventType, EventManager, FakeEvent, getLogger, Html5EventType} = core;
+const {AdBreakType, AdEventType, EventManager, FakeEvent, getLogger, Html5EventType, EngineDecoratorPriority} = core;
 /**
  * Engine decorator for ima dai plugin.
  * @class ImaDAIEngineDecorator
@@ -40,6 +40,10 @@ class ImaDAIEngineDecorator implements IEngineDecorator {
 
   get active(): boolean {
     return this._active;
+  }
+
+  get priority(): number {
+    return EngineDecoratorPriority.FALLBACK;
   }
 
   /**
@@ -212,17 +216,12 @@ class ImaDAIEngineDecorator implements IEngineDecorator {
   _attachListeners(): void {
     this._eventManager.listen(this._plugin.player, Html5EventType.PLAY, () => !this._plugin.isAdBreak() && (this._contentEnded = false));
     this._eventManager.listen(this._plugin.player, AdEventType.AD_BREAK_START, event => this._onAdBreakStart(event));
-    this._eventManager.listenOnce(this._plugin.player, AdEventType.AD_BREAK_END, () => (this._active = true));
   }
 
   _onAdBreakStart(event: EventManager): void {
     const adBreak = event.payload.adBreak;
     if (adBreak.type === AdBreakType.POST) {
       this._contentEnded = true;
-    }
-    if (!this._loadStart) {
-      // preroll from another ad plugin (e.g. bumper)
-      this._active = false;
     }
   }
 }

--- a/src/ima-dai-engine-decorator.js
+++ b/src/ima-dai-engine-decorator.js
@@ -113,7 +113,7 @@ class ImaDAIEngineDecorator implements IEngineDecorator {
     if (this._plugin.isAdBreak()) {
       this._plugin.resumeAd();
     }
-    this._engine.play();
+    this._engine.play().then(() => this._plugin._dispatchEventsOnFirstPlay());
   }
 
   /**

--- a/src/ima-dai-engine-decorator.js
+++ b/src/ima-dai-engine-decorator.js
@@ -19,7 +19,6 @@ class ImaDAIEngineDecorator implements IEngineDecorator {
   _eventManager: EventManager;
   _daiEventManager: ImaDAIEventManager;
   _active: boolean;
-  _loadStart: boolean;
   _contentEnded: boolean;
 
   constructor(engine: IEngine, plugin: ImaDAI, dispatchEventHandler: Function) {
@@ -34,7 +33,6 @@ class ImaDAIEngineDecorator implements IEngineDecorator {
 
   _initMembers(): void {
     this._active = true;
-    this._loadStart = false;
     this._contentEnded = false;
   }
 
@@ -60,7 +58,6 @@ class ImaDAIEngineDecorator implements IEngineDecorator {
     // When load comes from a user gesture need to open the video element synchronously
     this._engine.getVideoElement().load();
     return new Promise((resolve, reject) => {
-      this._loadStart = true;
       this._plugin.getStreamUrl().then(
         url => {
           this._logger.debug('Stream url has been fetched', url);

--- a/src/ima-dai-engine-decorator.js
+++ b/src/ima-dai-engine-decorator.js
@@ -113,7 +113,8 @@ class ImaDAIEngineDecorator implements IEngineDecorator {
     if (this._plugin.isAdBreak()) {
       this._plugin.resumeAd();
     }
-    this._engine.play().then(() => this._plugin._dispatchEventsOnFirstPlay());
+    const playPromise = this._engine.play();
+    playPromise ? playPromise.then(() => this._plugin._dispatchEventsOnFirstPlay()) : this._plugin._dispatchEventsOnFirstPlay();
   }
 
   /**

--- a/src/ima-dai-event-manager.js
+++ b/src/ima-dai-event-manager.js
@@ -81,12 +81,7 @@ class ImaDAIEventManager {
   }
 
   _onAdBreakEnd(): void {
-    if (this._queue.size() > 0) {
-      while (!this._queue.isEmpty()) {
-        const event = this._queue.pop();
-        this._dispatchEventHandler(event);
-      }
-    }
+    this._queue.dispatchAll(this._dispatchEventHandler);
   }
 }
 

--- a/src/ima-dai-event-queue.js
+++ b/src/ima-dai-event-queue.js
@@ -25,6 +25,15 @@ class ImaDAIEventQueue {
     }
   }
 
+  dispatchAll(dispatcher: Function): void {
+    if (this.size() > 0) {
+      while (!this.isEmpty()) {
+        const event = this.pop();
+        dispatcher(event);
+      }
+    }
+  }
+
   isEmpty(): boolean {
     return this.size() === 0;
   }

--- a/src/ima-dai.js
+++ b/src/ima-dai.js
@@ -387,7 +387,7 @@ class ImaDAI extends BasePlugin implements IAdsControllerProvider, IEngineDecora
   }
 
   _attachEngineListeners(): void {
-    this.eventManager.listen(this._engine, EventType.PLAY, () => this._onPlayRequest());
+    this.eventManager.listenOnce(this._engine, EventType.PLAY, () => this._onFirstPlayRequest());
     this.eventManager.listen(this._engine, EventType.LOADED_METADATA, () => this._onLoadedMetadata());
     this.eventManager.listen(this._engine, EventType.VOLUME_CHANGE, () => this._onVolumeChange());
     this.eventManager.listen(this._engine, 'hlsFragParsingMetadata', event => this._onHlsFragParsingMetadata(event));
@@ -463,7 +463,7 @@ class ImaDAI extends BasePlugin implements IAdsControllerProvider, IEngineDecora
     Object.keys(streamRequest).forEach(key => (streamRequest[key] = this.config[key] || streamRequest[key]));
   }
 
-  _onPlayRequest(): void {
+  _onFirstPlayRequest(): void {
     this._firstPlay = true;
     if (this._queue.size() > 0) {
       while (!this._queue.isEmpty()) {

--- a/src/ima-dai.js
+++ b/src/ima-dai.js
@@ -388,7 +388,6 @@ class ImaDAI extends BasePlugin implements IAdsControllerProvider, IEngineDecora
   }
 
   _attachEngineListeners(): void {
-    this.eventManager.listenOnce(this._engine, EventType.PLAY, () => this._onFirstPlayRequest());
     this.eventManager.listen(this._engine, EventType.VOLUME_CHANGE, () => this._onVolumeChange());
     this.eventManager.listen(this._engine, 'hlsFragParsingMetadata', event => this._onHlsFragParsingMetadata(event));
   }
@@ -461,24 +460,6 @@ class ImaDAI extends BasePlugin implements IAdsControllerProvider, IEngineDecora
 
   _assignStreamRequestParams(streamRequest: Object): void {
     Object.keys(streamRequest).forEach(key => (streamRequest[key] = this.config[key] || streamRequest[key]));
-  }
-
-  _onFirstPlayRequest(): void {
-    this._firstPlay = true;
-    if (this._queue.size() > 0) {
-      while (!this._queue.isEmpty()) {
-        const {name, payload} = this._queue.pop();
-        this._dispatchAdEvent(name, payload);
-      }
-    }
-  }
-
-  _delayDispatchAfterPlay(name: string, payload: any): void {
-    if (!this._firstPlay) {
-      this._queue.push({name, payload});
-    } else {
-      this._dispatchAdEvent(name, payload);
-    }
   }
 
   _onLoaded(event: Object): void {
@@ -687,6 +668,18 @@ class ImaDAI extends BasePlugin implements IAdsControllerProvider, IEngineDecora
     } else {
       this.logger.debug(type.toUpperCase(), payload);
       this.dispatchEvent(type, payload);
+    }
+  }
+
+  _dispatchEventsOnFirstPlay(): void {
+    if (!this._firstPlay) {
+      this._firstPlay = true;
+      if (this._queue.size() > 0) {
+        while (!this._queue.isEmpty()) {
+          const {type, payload} = this._queue.pop();
+          this._dispatchAdEvent(type, payload);
+        }
+      }
     }
   }
 

--- a/src/ima-dai.js
+++ b/src/ima-dai.js
@@ -277,6 +277,7 @@ class ImaDAI extends BasePlugin implements IAdsControllerProvider, IEngineDecora
       }
     });
     this.eventManager.listen(this.player, EventType.CHANGE_SOURCE_ENDED, () => {
+      this.eventManager.listen(this.player, EventType.LOADED_METADATA, () => this._onLoadedMetadata());
       this._attachEngineListeners();
     });
     this.eventManager.listen(this.player, EventType.TIME_UPDATE, () => {
@@ -388,7 +389,6 @@ class ImaDAI extends BasePlugin implements IAdsControllerProvider, IEngineDecora
 
   _attachEngineListeners(): void {
     this.eventManager.listenOnce(this._engine, EventType.PLAY, () => this._onFirstPlayRequest());
-    this.eventManager.listen(this._engine, EventType.LOADED_METADATA, () => this._onLoadedMetadata());
     this.eventManager.listen(this._engine, EventType.VOLUME_CHANGE, () => this._onVolumeChange());
     this.eventManager.listen(this._engine, 'hlsFragParsingMetadata', event => this._onHlsFragParsingMetadata(event));
   }

--- a/src/ima-dai.js
+++ b/src/ima-dai.js
@@ -311,14 +311,6 @@ class ImaDAI extends BasePlugin implements IAdsControllerProvider, IEngineDecora
         }
       }
     });
-    this.eventManager.listen(this.player, EventType.PLAY_FAILED, () => {
-      if (this._adBreak) {
-        this._onAdBreakEnded();
-        this.eventManager.listenOnce(this.player, EventType.FIRST_PLAY, () => {
-          this._onAdBreakStarted();
-        });
-      }
-    });
   }
 
   _init(): void {

--- a/src/ima-dai.js
+++ b/src/ima-dai.js
@@ -674,12 +674,10 @@ class ImaDAI extends BasePlugin implements IAdsControllerProvider, IEngineDecora
   _dispatchEventsOnFirstPlay(): void {
     if (!this._firstPlay) {
       this._firstPlay = true;
-      if (this._queue.size() > 0) {
-        while (!this._queue.isEmpty()) {
-          const {type, payload} = this._queue.pop();
-          this._dispatchAdEvent(type, payload);
-        }
-      }
+      this._queue.dispatchAll(event => {
+        const {type, payload} = event;
+        this._dispatchAdEvent(type, payload);
+      });
     }
   }
 


### PR DESCRIPTION
### Description of the Changes

Issue: load promise return the incorrect promise.
ima dai SDK fires ad_break_start and ad_start after load and before play request.
Solution: return a new promise on load which resolves or rejects on engine load rejection or resolves.
delay the ima dai SDK event to fires after play instead of the incorrect event after load which causes incorrect behavior on the player.

For the same video tag, we should use playAdsWithMSE.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
