### PR TITLE
fix(FEC-10265): Use adUiElement instead of deprecated setClickElement

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -1,6 +1,8 @@
 .playkit-dai-ads-cover {
-  position: relative;
+  position: absolute;
   cursor: pointer;
+  top: 0;
+  left: 0;
   width: 100%;
   height: 100%;
   background-color: rgba(0, 0, 0, 0);

--- a/src/ima-dai.js
+++ b/src/ima-dai.js
@@ -373,8 +373,7 @@ class ImaDAI extends BasePlugin implements IAdsControllerProvider, IEngineDecora
   _initStreamManager(): void {
     if (!this._streamManager) {
       this.logger.debug('Create stream manager');
-      this._streamManager = new this._sdk.api.StreamManager(this.player.getVideoElement());
-      this._streamManager.setClickElement(this._adsContainerDiv);
+      this._streamManager = new this._sdk.api.StreamManager(this.player.getVideoElement(), this._adsContainerDiv);
       this._attachStreamManagerListeners();
     }
   }


### PR DESCRIPTION
### Description of the Changes

Issue: setClick is deprecated and adds the element on adUiElement of StreamManager contractor change the DOM under IMA container which causes the cover to be on the bottom of the container instead hover over it. 
Solution:  change to adUiElmenet and set the cover on the top of the container which will handle the play/pause correctly even IMA sets the DOM element on the container.

Solves FEC-10265

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
