### PR TITLE
fix(FEC-10921): IMA & DAI seek doesn't works after pre-roll Ad finished

### DIFF
--- a/src/ima-dai-engine-decorator.js
+++ b/src/ima-dai-engine-decorator.js
@@ -66,8 +66,9 @@ class ImaDAIEngineDecorator implements IEngineDecorator {
         e => {
           this._logger.error(e);
           this._plugin.destroy();
-          this._active = false;
           this._engine.load(startTime).then(resolve, reject);
+          this._eventManager.removeAll();
+          this._active = false;
         }
       );
     });


### PR DESCRIPTION
### Description of the Changes

Issue: engine switch to active after adBreakEnd but the lib load failed so should remove the listeners which causes the engine to return to works on lib failed loading.
Solution: change the active state to false after we finished everything and remove the listener which causes the decorator to keeps working.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
