### PR TITLE
fix(FEC-11031): DAI doesn't work in change media after failure

### DIFF
--- a/src/ima-dai-engine-decorator.js
+++ b/src/ima-dai-engine-decorator.js
@@ -30,6 +30,9 @@ class ImaDAIEngineDecorator implements IEngineDecorator {
     this._logger = getLogger('ImaDAIEngineDecorator');
     this._initMembers();
     this._attachListeners();
+    this._plugin.player.addEventListener(this._plugin.player.Event.PLAYER_RESET, () => {
+      this.reset();
+    });
   }
 
   _initMembers(): void {
@@ -63,8 +66,7 @@ class ImaDAIEngineDecorator implements IEngineDecorator {
           this._engine.src = url;
           this._engine.load(this._plugin.getStreamTime(startTime)).then(resolve, reject);
         },
-        e => {
-          this._logger.error(e);
+        () => {
           this._plugin.destroy();
           this._engine.load(startTime).then(resolve, reject);
           this._eventManager.removeAll();


### PR DESCRIPTION
### Description of the Changes

Issue: DAI decorator is being inactive in failure so its `reset` doesnt invoke and it remains inactive for ever
Solution: set it active on `PLAYER_RESET`

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
