### PR TITLE
fix(FEC-11056): No replay button once ima postroll finished when imadai configured

### DIFF
--- a/src/ima-dai-state.js
+++ b/src/ima-dai-state.js
@@ -5,8 +5,6 @@
  * @type {Object}
  */
 const ImaDAIState: {[state: string]: string} = {
-  LOADING: 'loading',
-  LOADED: 'loaded',
   PLAYING: 'playing',
   PAUSED: 'paused',
   IDLE: 'idle',

--- a/src/ima-dai.js
+++ b/src/ima-dai.js
@@ -113,7 +113,6 @@ class ImaDAI extends BasePlugin implements IAdsControllerProvider, IEngineDecora
     return new Promise((resolve, reject) => {
       return this._loadPromise
         .then(() => {
-          this._state = ImaDAIState.LOADING;
           this._resolveLoad = resolve;
           this._rejectLoad = reject;
           this._initStreamManager();
@@ -328,7 +327,7 @@ class ImaDAI extends BasePlugin implements IAdsControllerProvider, IEngineDecora
   }
 
   _initMembers(): void {
-    this._state = ImaDAIState.IDLE;
+    this._state = ImaDAIState.DONE;
     this._cuePoints = [];
     this._adBreak = false;
     this._savedSeekTime = null;
@@ -404,6 +403,9 @@ class ImaDAI extends BasePlugin implements IAdsControllerProvider, IEngineDecora
       }
     });
     this._dispatchAdEvent(EventType.AD_MANIFEST_LOADED, {adBreaksPosition: adBreaksPosition});
+    if (adBreaksPosition.length > 0) {
+      this._state = ImaDAIState.IDLE;
+    }
     if (this.player.ui.hasManager('timeline') && this.config.showAdBreakCuePoint) {
       adBreaksPosition.forEach(position => {
         this.player.ui.getManager('timeline').addCuePoint({
@@ -459,7 +461,6 @@ class ImaDAI extends BasePlugin implements IAdsControllerProvider, IEngineDecora
 
   _onLoaded(event: Object): void {
     const streamData = event.getStreamData();
-    this._state = ImaDAIState.LOADED;
     this.logger.debug('Stream loaded', streamData);
     this._resolveLoad(streamData.url);
   }


### PR DESCRIPTION
### Description of the Changes

issue: The default state of imadai is `IDLE` so it's not "done" even it not active at all
Solution:  Change the default state to `DONE` and move to `IDLE` only once there are ads
also get rid `LOADED` and `LOADING` states as these states are about the ad,
and irrelevant in imadai at all as the ad is not loaded

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
