### PR TITLE
fix(FEC-11757): V3: live with Ad: UI wrong state (Video is paused) after closing the new opened Ad tab

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ dist: xenial
 language: node_js
 node_js:
   - 'node'
+env:
+  global:
+    - NODE_OPTIONS="--openssl-legacy-provider"
 
 addons:
   chrome: stable

--- a/src/ima-dai.js
+++ b/src/ima-dai.js
@@ -572,6 +572,8 @@ class ImaDAI extends BasePlugin implements IAdsControllerProvider, IEngineDecora
   _onAdPause() {
     this.player.pause();
     this.pauseAd();
+    this.player.play();
+    this.resumeAd();
   }
 
   _onAdBreakEnded(): void {

--- a/src/ima-dai.js
+++ b/src/ima-dai.js
@@ -443,6 +443,7 @@ class ImaDAI extends BasePlugin implements IAdsControllerProvider, IEngineDecora
     this._streamManager.addEventListener(this._sdk.api.StreamEvent.Type.THIRD_QUARTILE, () => this._onAdThirdQuartile());
     this._streamManager.addEventListener(this._sdk.api.StreamEvent.Type.COMPLETE, () => this._onAdCompleteFromSDK());
     this._streamManager.addEventListener(this._sdk.api.StreamEvent.Type.CLICK, () => this._onAdClickFromSDK());
+    this._streamManager.addEventListener(this._sdk.api.StreamEvent.Type.PAUSED, () => this._onAdPause());
   }
 
   _requestVODStream(): void {
@@ -566,6 +567,11 @@ class ImaDAI extends BasePlugin implements IAdsControllerProvider, IEngineDecora
         this.pauseAd();
       }
     }
+  }
+
+  _onAdPause() {
+    this.player.pause();
+    this.pauseAd();
   }
 
   _onAdBreakEnded(): void {

--- a/src/ima-dai.js
+++ b/src/ima-dai.js
@@ -566,14 +566,14 @@ class ImaDAI extends BasePlugin implements IAdsControllerProvider, IEngineDecora
         this.player.pause();
         this.pauseAd();
       }
+    } else if (this._state === ImaDAIState.PAUSED && this.player.isLive()) {
+      this.player.play();
+      this.resumeAd();
     }
   }
 
   _onAdPause() {
-    this.player.pause();
     this.pauseAd();
-    this.player.play();
-    this.resumeAd();
   }
 
   _onAdBreakEnded(): void {

--- a/src/ima-dai.js
+++ b/src/ima-dai.js
@@ -566,7 +566,7 @@ class ImaDAI extends BasePlugin implements IAdsControllerProvider, IEngineDecora
         this.player.pause();
         this.pauseAd();
       }
-    } else if (this._state === ImaDAIState.PAUSED && this.player.isLive()) {
+    } else if (this._state === ImaDAIState.PAUSED) {
       this.player.play();
       this.resumeAd();
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1886,9 +1886,9 @@ camelcase@^6.0.0:
   integrity sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==
 
 caniuse-lite@^1.0.30001093:
-  version "1.0.30001105"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001105.tgz#d2cb0b31e5cf2f3ce845033b61c5c01566549abf"
-  integrity sha512-JupOe6+dGMr7E20siZHIZQwYqrllxotAhiaej96y6x00b/48rPt42o+SzOSCPbrpsDWvRja40Hwrj0g0q6LZJg==
+  version "1.0.30001292"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001292.tgz"
+  integrity sha512-jnT4Tq0Q4ma+6nncYQVe7d73kmDmE9C3OGTx3MvW7lBM/eY1S1DZTMBON7dqV481RhNiS5OxD7k9JQvmDOTirw==
 
 chai@^4.2.0:
   version "4.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1886,9 +1886,9 @@ camelcase@^6.0.0:
   integrity sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==
 
 caniuse-lite@^1.0.30001093:
-  version "1.0.30001292"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001292.tgz"
-  integrity sha512-jnT4Tq0Q4ma+6nncYQVe7d73kmDmE9C3OGTx3MvW7lBM/eY1S1DZTMBON7dqV481RhNiS5OxD7k9JQvmDOTirw==
+  version "1.0.30001105"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001105.tgz#d2cb0b31e5cf2f3ce845033b61c5c01566549abf"
+  integrity sha512-JupOe6+dGMr7E20siZHIZQwYqrllxotAhiaej96y6x00b/48rPt42o+SzOSCPbrpsDWvRja40Hwrj0g0q6LZJg==
 
 chai@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
### Description of the Changes

**issue:**  ima launched the new “pause” behavior since April 16, 2021 look at  https://ads-developers.googleblog.com/2020/09/changes-to-pause-behavior-in.html 

**fix:**  resume the ad manually on live

solves: FEC-11757

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
