### PR TITLE
fix(FEC-9421): DAI plugin doesn't mask playback events during ad

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 dist: xenial
 language: node_js
 node_js:
-  - 'node'
+  - '17'
 env:
   global:
     - NODE_OPTIONS="--openssl-legacy-provider"

--- a/src/ima-dai-event-queue.js
+++ b/src/ima-dai-event-queue.js
@@ -3,7 +3,7 @@ import {core} from 'kaltura-player-js';
 const {FakeEvent, getLogger, Html5EventType} = core;
 
 class ImaDAIEventQueue {
-  _ignore: Array<string> = [Html5EventType.TIME_UPDATE, Html5EventType.PROGRESS];
+  _ignore: Array<string> = [Html5EventType.TIME_UPDATE, Html5EventType.PROGRESS, Html5EventType.PLAY, Html5EventType.PAUSE];
   _queue: Array<FakeEvent>;
   _logger: Object;
 


### PR DESCRIPTION
**the issue:**
DAI plugin doesn't mask playback events (play & pause) during ad.

**root cause:**
the events are being added to a queue and when the ad ends, ImaDAIEventManager dispatches all events in that queue, including play and pause events.

### Description of the Changes

adding Html5EventType.PLAY, Html5EventType.PAUSE to ignore array of ImaDAIEventQueue object.

Solves FEC-9421

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
